### PR TITLE
Implement ingredient search api

### DIFF
--- a/src/main/java/dayum/dayumserver/application/ingredient/IngredientController.java
+++ b/src/main/java/dayum/dayumserver/application/ingredient/IngredientController.java
@@ -1,0 +1,24 @@
+package dayum.dayumserver.application.ingredient;
+
+import dayum.dayumserver.application.common.response.ApiResponse;
+import dayum.dayumserver.application.ingredient.dto.IngredientResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/ingredients")
+public class IngredientController {
+
+  private final IngredientService ingredientService;
+
+  @GetMapping
+  public ApiResponse<List<IngredientResponse>> searchIngredients(@RequestParam String keyword) {
+    var ingredients = ingredientService.search(keyword);
+    return ApiResponse.of(ingredients);
+  }
+}

--- a/src/main/java/dayum/dayumserver/application/ingredient/IngredientService.java
+++ b/src/main/java/dayum/dayumserver/application/ingredient/IngredientService.java
@@ -1,0 +1,18 @@
+package dayum.dayumserver.application.ingredient;
+
+import dayum.dayumserver.application.ingredient.dto.IngredientResponse;
+import dayum.dayumserver.domain.ingredient.IngredientRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class IngredientService {
+
+  private final IngredientRepository ingredientRepository;
+
+  public List<IngredientResponse> search(String keyword) {
+    return ingredientRepository.search(keyword).stream().map(IngredientResponse::from).toList();
+  }
+}

--- a/src/main/java/dayum/dayumserver/application/ingredient/dto/IngredientResponse.java
+++ b/src/main/java/dayum/dayumserver/application/ingredient/dto/IngredientResponse.java
@@ -1,0 +1,10 @@
+package dayum.dayumserver.application.ingredient.dto;
+
+import dayum.dayumserver.domain.ingredient.Ingredient;
+
+public record IngredientResponse(Long id, String name) {
+
+  public static IngredientResponse from(Ingredient ingredient) {
+    return new IngredientResponse(ingredient.id(), ingredient.name());
+  }
+}

--- a/src/main/java/dayum/dayumserver/domain/ingredient/IngredientRepository.java
+++ b/src/main/java/dayum/dayumserver/domain/ingredient/IngredientRepository.java
@@ -1,3 +1,8 @@
 package dayum.dayumserver.domain.ingredient;
 
-public interface IngredientRepository {}
+import java.util.List;
+
+public interface IngredientRepository {
+
+  List<Ingredient> search(String keyword);
+}

--- a/src/main/java/dayum/dayumserver/infrastructure/repository/IngredientRepositoryJpaAdaptor.java
+++ b/src/main/java/dayum/dayumserver/infrastructure/repository/IngredientRepositoryJpaAdaptor.java
@@ -18,6 +18,7 @@ public class IngredientRepositoryJpaAdaptor implements IngredientRepository {
 
   @Override
   public List<Ingredient> search(String keyword) {
+    // TODO(chanjun.park): Update it after finalizing the ingredient search policy
     return ingredientJpaRepository.findAllByNameLike("%" + keyword + "%", Limit.of(10)).stream()
         .map(ingredientMapper::mapToDomainEntity)
         .toList();

--- a/src/main/java/dayum/dayumserver/infrastructure/repository/IngredientRepositoryJpaAdaptor.java
+++ b/src/main/java/dayum/dayumserver/infrastructure/repository/IngredientRepositoryJpaAdaptor.java
@@ -1,8 +1,12 @@
 package dayum.dayumserver.infrastructure.repository;
 
+import dayum.dayumserver.domain.ingredient.Ingredient;
 import dayum.dayumserver.domain.ingredient.IngredientRepository;
 import dayum.dayumserver.infrastructure.repository.jpa.repository.IngredientJpaRepository;
+import dayum.dayumserver.infrastructure.repository.mapper.IngredientMapper;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -10,4 +14,12 @@ import org.springframework.stereotype.Repository;
 public class IngredientRepositoryJpaAdaptor implements IngredientRepository {
 
   private final IngredientJpaRepository ingredientJpaRepository;
+  private final IngredientMapper ingredientMapper;
+
+  @Override
+  public List<Ingredient> search(String keyword) {
+    return ingredientJpaRepository.findAllByNameLike("%" + keyword + "%", Limit.of(10)).stream()
+        .map(ingredientMapper::mapToDomainEntity)
+        .toList();
+  }
 }

--- a/src/main/java/dayum/dayumserver/infrastructure/repository/jpa/entity/ContentsIngredientJpaEntity.java
+++ b/src/main/java/dayum/dayumserver/infrastructure/repository/jpa/entity/ContentsIngredientJpaEntity.java
@@ -29,10 +29,18 @@ public class ContentsIngredientJpaEntity extends BaseEntity {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "contents_id", referencedColumnName = "contents_id", foreignKey = @ForeignKey(NO_CONSTRAINT))
+  @JoinColumn(
+      name = "contents_id",
+      referencedColumnName = "contents_id",
+      foreignKey = @ForeignKey(NO_CONSTRAINT))
   private ContentsJpaEntity contents;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "ingredient_id", referencedColumnName = "ingredient_id", foreignKey = @ForeignKey(NO_CONSTRAINT))
+  @JoinColumn(
+      name = "ingredient_id",
+      referencedColumnName = "ingredient_id",
+      foreignKey = @ForeignKey(NO_CONSTRAINT))
   private IngredientJpaEntity ingredient;
+
+  private Long quantity;
 }

--- a/src/main/java/dayum/dayumserver/infrastructure/repository/jpa/entity/ContentsJpaEntity.java
+++ b/src/main/java/dayum/dayumserver/infrastructure/repository/jpa/entity/ContentsJpaEntity.java
@@ -30,7 +30,10 @@ public class ContentsJpaEntity extends BaseEntity {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "member_id", referencedColumnName = "member_id", foreignKey = @ForeignKey(NO_CONSTRAINT))
+  @JoinColumn(
+      name = "member_id",
+      referencedColumnName = "member_id",
+      foreignKey = @ForeignKey(NO_CONSTRAINT))
   private MemberJpaEntity member;
 
   private String title;

--- a/src/main/java/dayum/dayumserver/infrastructure/repository/jpa/repository/IngredientJpaRepository.java
+++ b/src/main/java/dayum/dayumserver/infrastructure/repository/jpa/repository/IngredientJpaRepository.java
@@ -1,8 +1,13 @@
 package dayum.dayumserver.infrastructure.repository.jpa.repository;
 
 import dayum.dayumserver.infrastructure.repository.jpa.entity.IngredientJpaEntity;
+import java.util.List;
+import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface IngredientJpaRepository extends JpaRepository<IngredientJpaEntity, Long> {}
+public interface IngredientJpaRepository extends JpaRepository<IngredientJpaEntity, Long> {
+
+  List<IngredientJpaEntity> findAllByNameLike(String name, Limit limit);
+}

--- a/src/main/java/dayum/dayumserver/infrastructure/repository/mapper/IngredientMapper.java
+++ b/src/main/java/dayum/dayumserver/infrastructure/repository/mapper/IngredientMapper.java
@@ -1,0 +1,11 @@
+package dayum.dayumserver.infrastructure.repository.mapper;
+
+import dayum.dayumserver.domain.ingredient.Ingredient;
+import dayum.dayumserver.infrastructure.repository.jpa.entity.IngredientJpaEntity;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface IngredientMapper {
+
+  Ingredient mapToDomainEntity(IngredientJpaEntity ingredientJpaEntity);
+}


### PR DESCRIPTION
## Changes
1. Keyword 로 재료를 검색할 수 있는 API 를 추가합니다.

## Memo
1. 아직 재료 검색에 대한 정책이 정확하게 결정되지 않아`LIKE '%Keyword%'` 을 기반으로 작성했습니다.
Client 와 기획과 논의후 해당 부분이 변경될 수 있어 TODO 를 남겼습니다.

## Testing
```
GET http://localhost:8080/api/ingredients?keyword=소금

{
  "data": [
    {
      "id": 109,
      "name": "깨소금"
    },
    {
      "id": 507,
      "name": "소금"
    }
  ],
  "success": true
}
```