### PR TITLE
Add nutritional field in ContentsResponse & ContentsDetailResponse

### DIFF
--- a/src/main/java/dayum/dayumserver/application/contents/dto/ContentsDetailResponse.java
+++ b/src/main/java/dayum/dayumserver/application/contents/dto/ContentsDetailResponse.java
@@ -3,7 +3,6 @@ package dayum.dayumserver.application.contents.dto;
 import dayum.dayumserver.domain.contents.Contents;
 import java.time.LocalDateTime;
 
-// TODO(chanjun.park): Add fields for nutritional information
 public record ContentsDetailResponse(
     long id,
     long memberId,

--- a/src/main/java/dayum/dayumserver/application/contents/dto/ContentsDetailResponse.java
+++ b/src/main/java/dayum/dayumserver/application/contents/dto/ContentsDetailResponse.java
@@ -10,6 +10,10 @@ public record ContentsDetailResponse(
     String memberNickname,
     String thumbnailUrl,
     String url,
+    double calories,
+    double carbohydrates,
+    double proteins,
+    double fats,
     LocalDateTime uploadedAt) {
 
   public static ContentsDetailResponse from(Contents contents) {
@@ -19,6 +23,10 @@ public record ContentsDetailResponse(
         contents.member().nickname(),
         contents.url(),
         contents.thumbnailUrl(),
+        contents.calculateCalories(),
+        contents.calculateCarbohydrates(),
+        contents.calculateProteins(),
+        contents.calculateFats(),
         contents.createdAt());
   }
 }

--- a/src/main/java/dayum/dayumserver/application/contents/dto/ContentsResponse.java
+++ b/src/main/java/dayum/dayumserver/application/contents/dto/ContentsResponse.java
@@ -2,9 +2,23 @@ package dayum.dayumserver.application.contents.dto;
 
 import dayum.dayumserver.domain.contents.Contents;
 
-public record ContentsResponse(long id, String thumbnailUrl, String url) {
+public record ContentsResponse(
+    long id,
+    String thumbnailUrl,
+    String url,
+    double calories,
+    double carbohydrates,
+    double proteins,
+    double fats) {
 
   public static ContentsResponse from(Contents contents) {
-    return new ContentsResponse(contents.id(), contents.thumbnailUrl(), contents.url());
+    return new ContentsResponse(
+        contents.id(),
+        contents.thumbnailUrl(),
+        contents.url(),
+        contents.calculateCalories(),
+        contents.calculateCarbohydrates(),
+        contents.calculateProteins(),
+        contents.calculateFats());
   }
 }

--- a/src/main/java/dayum/dayumserver/domain/contents/Contents.java
+++ b/src/main/java/dayum/dayumserver/domain/contents/Contents.java
@@ -1,6 +1,5 @@
 package dayum.dayumserver.domain.contents;
 
-import dayum.dayumserver.domain.ingredient.Ingredient;
 import dayum.dayumserver.domain.member.Member;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -10,5 +9,24 @@ public record Contents(
     Member member,
     String thumbnailUrl,
     String url,
-    List<Ingredient> ingredients,
-    LocalDateTime createdAt) {}
+    List<ContentsIngredient> ingredients,
+    LocalDateTime createdAt) {
+
+  public double calculateCalories() {
+    return ingredients.stream().mapToDouble(it -> it.ingredient().calories() * it.quantity()).sum();
+  }
+
+  public double calculateCarbohydrates() {
+    return ingredients.stream()
+        .mapToDouble(it -> it.ingredient().carbohydrates() * it.quantity())
+        .sum();
+  }
+
+  public double calculateProteins() {
+    return ingredients.stream().mapToDouble(it -> it.ingredient().proteins() * it.quantity()).sum();
+  }
+
+  public double calculateFats() {
+    return ingredients.stream().mapToDouble(it -> it.ingredient().fats() * it.quantity()).sum();
+  }
+}

--- a/src/main/java/dayum/dayumserver/domain/contents/ContentsIngredient.java
+++ b/src/main/java/dayum/dayumserver/domain/contents/ContentsIngredient.java
@@ -1,0 +1,5 @@
+package dayum.dayumserver.domain.contents;
+
+import dayum.dayumserver.domain.ingredient.Ingredient;
+
+public record ContentsIngredient(Ingredient ingredient, long quantity) {}

--- a/src/main/java/dayum/dayumserver/infrastructure/repository/ContentsRepositoryJpaAdaptor.java
+++ b/src/main/java/dayum/dayumserver/infrastructure/repository/ContentsRepositoryJpaAdaptor.java
@@ -6,6 +6,7 @@ import dayum.dayumserver.infrastructure.repository.jpa.repository.ContentsJpaRep
 import dayum.dayumserver.infrastructure.repository.mapper.ContentsMapper;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,14 +20,16 @@ public class ContentsRepositoryJpaAdaptor implements ContentsRepository {
 
   @Override
   public List<Contents> fetchNextPageByMember(long memberId, long cursorId, int size) {
-    return contentsJpaRepository.findNextPageByMember(memberId, cursorId, size).stream()
+    var page = PageRequest.of(0, size);
+    return contentsJpaRepository.findNextPageByMember(memberId, cursorId, page).stream()
         .map(contentsMapper::mapToDomainEntity)
         .toList();
   }
 
   @Override
   public List<Contents> fetchNextPage(long cursorId, int size) {
-    return contentsJpaRepository.findNextPage(cursorId, size).stream()
+    var page = PageRequest.of(0, size);
+    return contentsJpaRepository.findNextPage(cursorId, page).stream()
         .map(contentsMapper::mapToDomainEntity)
         .toList();
   }

--- a/src/main/java/dayum/dayumserver/infrastructure/repository/jpa/entity/ContentsJpaEntity.java
+++ b/src/main/java/dayum/dayumserver/infrastructure/repository/jpa/entity/ContentsJpaEntity.java
@@ -12,7 +12,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,14 +39,24 @@ public class ContentsJpaEntity extends BaseEntity {
       foreignKey = @ForeignKey(NO_CONSTRAINT))
   private MemberJpaEntity member;
 
+  @OneToMany(mappedBy = "contents", fetch = FetchType.LAZY)
+  private List<ContentsIngredientJpaEntity> ingredients = new ArrayList<>();
+
   private String title;
   private String description;
   private String thumbnailUrl;
   private String url;
 
   @Builder
-  public ContentsJpaEntity(MemberJpaEntity member, String title, String description, String thumbnailUrl, String url) {
+  public ContentsJpaEntity(
+      MemberJpaEntity member,
+      List<ContentsIngredientJpaEntity> ingredients,
+      String title,
+      String description,
+      String thumbnailUrl,
+      String url) {
     this.member = member;
+    this.ingredients = ingredients;
     this.title = title;
     this.description = description;
     this.thumbnailUrl = thumbnailUrl;

--- a/src/main/java/dayum/dayumserver/infrastructure/repository/jpa/repository/ContentsJpaRepository.java
+++ b/src/main/java/dayum/dayumserver/infrastructure/repository/jpa/repository/ContentsJpaRepository.java
@@ -2,6 +2,8 @@ package dayum.dayumserver.infrastructure.repository.jpa.repository;
 
 import dayum.dayumserver.infrastructure.repository.jpa.entity.ContentsJpaEntity;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,19 +14,32 @@ public interface ContentsJpaRepository extends JpaRepository<ContentsJpaEntity, 
 
   @Query(
       "SELECT contents "
-          + "FROM ContentsJpaEntity contents " 
+          + "FROM ContentsJpaEntity contents "
           + "JOIN FETCH contents.member "
+          + "JOIN FETCH contents.ingredients ci "
+          + "JOIN FETCH ci.ingredient "
           + "WHERE contents.member.id = :memberId "
           + "AND contents.id >= :cursorId "
-          + "ORDER BY contents.id "
-          + "LIMIT :size")
-  List<ContentsJpaEntity> findNextPageByMember(@Param("memberId") long memberId, @Param("cursorId") long cursorId, @Param("size") int size);
+          + "ORDER BY contents.id")
+  List<ContentsJpaEntity> findNextPageByMember(
+      @Param("memberId") long memberId, @Param("cursorId") long cursorId, Pageable page);
 
   @Query(
       "SELECT contents "
           + "FROM ContentsJpaEntity contents "
+          + "JOIN FETCH contents.member "
+          + "JOIN FETCH contents.ingredients ci "
+          + "JOIN FETCH ci.ingredient "
           + "WHERE contents.id >= :cursorId "
-          + "ORDER BY contents.id "
-          + "LIMIT :size")
-  List<ContentsJpaEntity> findNextPage(@Param("cursorId") long cursorId, @Param("size") int size);
+          + "ORDER BY contents.id")
+  List<ContentsJpaEntity> findNextPage(@Param("cursorId") long cursorId, Pageable page);
+
+  @Query(
+      "SELECT contents "
+          + "FROM ContentsJpaEntity contents "
+          + "JOIN FETCH contents.member "
+          + "JOIN FETCH contents.ingredients ci "
+          + "JOIN FETCH ci.ingredient "
+          + "WHERE contents.id = :id")
+  Optional<ContentsJpaEntity> findById(@Param("id") long id);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,7 @@ spring:
       hibernate:
         format_sql: ${SPRING_JPA_FORMAT_SQL:false}
         dialect: org.hibernate.dialect.MySQLDialect
+        default_batch_fetch_size: 1000
 
 ncp:
   region: kr-standard


### PR DESCRIPTION
## Changes
1. `ContentsResponse`, `ContentsDetailResponse` 에 영양정보를 포함하도록 응답 모델을 수정합니다.
2. `Contents` 를 조회할 때 발생하는 N+1 문제를 해결합니다.
3. 실수로 N+1 문제가 발생했을때를 대비해 `hibernate.default_batch_fetch_size: 1000` 옵션을 추가합니다.

## Testing
```
GET http://localhost:8080/api/contents?cursor=1&size=2

{
  "data": {
    "items": [
      {
        "id": 1,
        "thumbnailUrl": "sample",
        "url": "sample",
        "calories": 380.0,
        "carbohydrates": 79.35,
        "proteins": 28.35,
        "fats": 3.5
      }
    ],
    "pageInfo": {
      "nextCursor": "",
      "isLastPage": true
    }
  },
  "success": true
}

GET http://localhost:8080/api/contents/1

{
  "data": {
    "id": 1,
    "memberId": 1,
    "memberNickname": "wiz",
    "thumbnailUrl": "sample",
    "url": "sample",
    "calories": 380.0,
    "carbohydrates": 79.35,
    "proteins": 28.35,
    "fats": 3.5,
    "uploadedAt": "2025-08-04T00:16:33"
  },
  "success": true
}
```